### PR TITLE
Improve instructions for selecting ZIP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ python extrava/manage.py runserver
 
 4. Visit `http://localhost:8000` to log in and start uploading data.
 
+### Uploading your export
+
+On the home page click **Select ZIP file** and choose the Strava export `*.zip`
+you downloaded from Strava. After selecting the file press **Analyze Locally**
+to review the activities contained inside. Tick or untick each entry and finally
+click **Upload Selected** to save them on the server.
+
 ## Notes
 
 - Static files including `jszip.min.js` are served locally when `DEBUG` is true.

--- a/extrava/dashboard/templates/dashboard/home.html
+++ b/extrava/dashboard/templates/dashboard/home.html
@@ -1,8 +1,11 @@
 {% extends 'dashboard/base.html' %}
 {% block content %}
 <h1 class="title">Upload Strava Export</h1>
+<p class="mb-2">Choose your Strava export <code>.zip</code> file and then click
+    <strong>Analyze Locally</strong> to inspect its contents.</p>
 <!-- File selection and analysis controls -->
 <div class="box">
+    <label class="label" for="export-file">Select ZIP file</label>
     <input id="export-file" type="file" accept=".zip" class="file-input">
     <button id="analyze-btn" class="button is-link mt-2">Analyze Locally</button>
     <div id="analysis" class="mt-4"></div>
@@ -25,14 +28,15 @@
 </table>
 <script src="/static/jszip.min.js"></script>
 <script>
-// Elements used by the analysis and upload workflow
-const fileInput = document.getElementById('export-file');
-const analyzeBtn = document.getElementById('analyze-btn');
-const uploadBtn = document.getElementById('upload-btn');
-// Parsed activity data is stored here until uploaded
+// Grab references to page elements used below
+const fileInput = document.getElementById('export-file');  // file chooser
+const analyzeBtn = document.getElementById('analyze-btn'); // start analysis
+const uploadBtn = document.getElementById('upload-btn');   // upload results
+// Parsed activity data is stored here until the user uploads it
 let parsedData = [];
 
-// When "Analyze Locally" is clicked parse the ZIP and show checkboxes
+// When "Analyze Locally" is clicked parse the ZIP and display one
+// checkbox per activity found in the export
 analyzeBtn.onclick = async function() {
     if (!fileInput.files.length) return alert('Select a file');
     const file = fileInput.files[0];
@@ -64,7 +68,12 @@ uploadBtn.onclick = async function() {
     if (!toSend.length) { alert('Nothing selected'); return; }
     const form = new FormData();
     form.append('entries', JSON.stringify(toSend));
-    const res = await fetch('{% url "dashboard:upload" %}', {method: 'POST', body: form, headers: {'X-CSRFToken': '{{ csrf_token }}'}});
+    // Send the selected rows to the Django backend using Fetch
+    const res = await fetch('{% url "dashboard:upload" %}', {
+        method: 'POST',
+        body: form,
+        headers: {'X-CSRFToken': '{{ csrf_token }}'}
+    });
     if (res.ok) location.reload(); else alert('Upload failed');
 };
 </script>


### PR DESCRIPTION
## Summary
- clarify how to pick your Strava export ZIP in the README
- add a label and helper text to the upload form
- document the JavaScript for analyzing and uploading activities

## Testing
- `pip install -r reqs.txt`
- `python extrava/manage.py test dashboard`


------
https://chatgpt.com/codex/tasks/task_e_6884f2d8d24483289475e675367f4758