### PR TITLE
Fix upload parsing

### DIFF
--- a/extrava/dashboard/templates/dashboard/home.html
+++ b/extrava/dashboard/templates/dashboard/home.html
@@ -43,11 +43,50 @@ analyzeBtn.onclick = async function() {
     // JSZip reads the ZIP archive directly in the browser
     const zip = await JSZip.loadAsync(file);
     const csv = await zip.file('activities.csv').async('string');
-    const lines = csv.trim().split(/\r?\n/).slice(1); // skip header row
+
+    // CSV files exported from Strava contain quoted fields with embedded commas,
+    // so splitting on commas alone will break the values.  The helper below
+    // performs a minimal parse of a single CSV line, honouring quoted fields.
+    function splitCsvLine(line) {
+        const fields = [];
+        let field = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i++) {
+            const ch = line[i];
+            if (ch === '"') {
+                // Toggle the quoted state unless this is an escaped quote
+                if (line[i + 1] === '"') {
+                    field += '"';
+                    i++; // Skip the escaped quote
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (ch === ',' && !inQuotes) {
+                fields.push(field);
+                field = '';
+            } else {
+                field += ch;
+            }
+        }
+        fields.push(field);
+        return fields;
+    }
+
+    // Determine which CSV columns hold the data we care about by inspecting the
+    // header row. This ensures the parsing still works if column positions ever
+    // change in future exports.
+    const lines = csv.trim().split(/\r?\n/);
+    const header = splitCsvLine(lines[0]);
+    const idIdx = header.indexOf('Activity ID');
+    const distIdx = header.indexOf('Distance');
+    const durIdx = header.indexOf('Elapsed Time');
     const container = document.getElementById('analysis');
     container.innerHTML = '';
-    parsedData = lines.map(line => {
-        const [id, distance, duration] = line.split(',');
+    parsedData = lines.slice(1).map(line => {
+        const cols = splitCsvLine(line);
+        const id = cols[idIdx];
+        const distance = cols[distIdx];
+        const duration = cols[durIdx];
         const row = document.createElement('div');
         row.innerHTML = `<label class="checkbox"><input type="checkbox" checked data-id="${id}" data-distance="${distance}" data-duration="${duration}"> ${id} - ${distance} km</label>`;
         container.appendChild(row);

--- a/extrava/dashboard/views.py
+++ b/extrava/dashboard/views.py
@@ -37,11 +37,15 @@ def upload_data(request):
 
     # Persist each uploaded activity for later analysis
     for row in data:
-        Activity.objects.create(
-            user=request.user,
-            activity_id=row.get("id", ""),
-            distance=float(row.get("distance", 0)),
-            duration=int(row.get("duration", 0)),
-        )
+        try:
+            Activity.objects.create(
+                user=request.user,
+                activity_id=row.get("id", ""),
+                distance=float(row.get("distance", 0)),
+                duration=int(row.get("duration", 0)),
+            )
+        except (TypeError, ValueError) as exc:
+            # If any row cannot be parsed, inform the client so they can fix the data
+            return JsonResponse({"error": str(exc)}, status=400)
 
     return JsonResponse({"status": "ok"})


### PR DESCRIPTION
## Summary
- handle quoted CSV fields in the browser when analyzing the Strava export
- report parsing failures gracefully in the upload API

## Testing
- `python3 -m pip install -r reqs.txt`
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688501788fd8832894c237799c608b4f