### PR TITLE
Add Windows helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ and runs migrations automatically. You can optionally pass a port number:
 
 Omitting the argument will default to port `8000`.
 
+### Running on Windows
+
+Windows users can take advantage of the `run_windows.bat` script. It
+creates a virtual environment, installs dependencies, runs migrations
+and finally launches the development server. Pass a port number as the
+first argument to change the port:
+
+```cmd
+run_windows.bat 8080  && REM serves on port 8080
+```
+
+If omitted the server will listen on port `8000`.
+
 ### Uploading your export
 
 On the home page click **Select ZIP file** and choose the Strava export `*.zip`

--- a/run_windows.bat
+++ b/run_windows.bat
@@ -1,0 +1,37 @@
+@echo off
+rem Helper script to run the Extrava project on Windows.
+rem Optionally specify a port number as the first argument. Defaults to 8000.
+
+setlocal enableextensions
+
+rem Use the first command line argument as the port number
+set "PORT=%1"
+if "%PORT%"=="" set "PORT=8000"
+
+rem Determine the directory of this script so relative paths work from anywhere
+set "ROOT_DIR=%~dp0"
+
+rem Virtual environment directory
+set "VENV_PATH=%ROOT_DIR%venv"
+
+rem Create the virtual environment if it doesn't exist
+if not exist "%VENV_PATH%" (
+    python -m venv "%VENV_PATH%"
+)
+
+rem Activate the environment
+call "%VENV_PATH%\Scripts\activate.bat"
+
+rem Install required Python packages
+pip install -r "%ROOT_DIR%reqs.txt"
+
+rem Run migrations to update the database
+python "%ROOT_DIR%extrava\manage.py" migrate
+
+rem Create default admin user if necessary
+python "%ROOT_DIR%extrava\manage.py" create_default_admin
+
+rem Launch Django's development server on the chosen port
+python "%ROOT_DIR%extrava\manage.py" runserver 0.0.0.0:%PORT%
+
+endlocal


### PR DESCRIPTION
## Summary
- add `run_windows.bat` that installs deps and starts the app on a chosen port
- document Windows script usage in README

## Testing
- `python extrava/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6885017dca808328a8b0ed05444ce0b3